### PR TITLE
Updating tests to pass, since we changed key in fabric config set to an enum

### DIFF
--- a/robotfm_tests/002_Verify_User_Defined_Fabric.rst
+++ b/robotfm_tests/002_Verify_User_Defined_Fabric.rst
@@ -236,9 +236,15 @@
         Should Contain   ${output.stdout}   Cannot delete a default fabric
 
     Fabric config for non-existent fabric
-        BWC add fabric parameters TEMPLATE     key  value  ${NO FABRIC}  Fabric: ${NO FABRIC} does not exist.
-        BWC delete fabric parameters TEMPLATE  key         ${NO FABRIC}  Fabric: ${NO FABRIC} does not exist.
-        BWC fabric config show TEMPLATE                    ${NO FABRIC}  Fabric does not exist: ${NO FABRIC}
+        ${output}=       Run Process   bwc  dcf  fabric   config  set  fabric\=${NO FABRIC}  key\=loopback_port_number  value\=1
+        Log To Console  \nOUTPUT:\n${output.stdout}\nERR:\n${output.stderr}\nRC:\n${output.rc}
+        Should Contain   ${output.stdout}   Fabric: ${NO FABRIC} does not exist.
+        ${output}=       Run Process  bwc  dcf  fabric   config  delete  fabric\=${NO FABRIC}  key\=loopback_port_number
+        Log To Console   DEL LOG: \n${output.stdout} \nRC: ${output.rc} \nERROR: ${output.stderr}
+        Should Contain   ${output.stdout}   Fabric: ${NO FABRIC} does not exist.
+        ${output}=       Run Process   bwc  dcf  fabric  config  show  fabric\=${NO FABRIC}
+        Log To Console  \nOUTPUT:\n${output.stdout}\nERR:\n${output.stderr}\nRC:\n${output.rc}
+        Should Contain   ${output.stdout}   Fabric does not exist: ${NO FABRIC}
 
     *** Settings ***
     Library             OperatingSystem


### PR DESCRIPTION
Here's the output when running just that test

(venv) st2admin@ubuntu1604:~/bwc-tests/robotfm_tests$ pybot 002_Verify_User_Defined_Fabric.rst
==============================================================================
002 Verify User Defined Fabric
==============================================================================
Fabric config for non-existent fabric                                 .
OUTPUT:

Operation failed:
Failure Reason: st2.actions.python.SetFabricConfig: DEBUG    PUT http://127.0.0.1:8888/v1/fabric with data {'value': u'1', 'fabric': 'no_fabric', 'key': u'loopback_port_number'}
Traceback (most recent call last):
  File "/opt/stackstorm/st2/local/lib/python2.7/site-packages/st2common/runners/python_action_wrapper.py", line 259, in <module>
    obj.run()
  File "/opt/stackstorm/st2/local/lib/python2.7/site-packages/st2common/runners/python_action_wrapper.py", line 155, in run
    output = action.run(**self._parameters)
  File "/opt/stackstorm/packs/network_inventory/actions/fabric_config_set.py", line 29, in run
    value=value)
  File "/opt/stackstorm/packs/network_inventory/actions/fabric_config_set.py", line 57, in _set_fabric_config
    raise ValueError('Fabric: %s does not exist.' % fabric_name)
ValueError: Fabric: no_fabric does not exist.

Please run 'st2 execution get 59dc10e84066ae3f06b840d1' to get details of failure
ERR:

RC:
1
...DEL LOG:

Operation failed:
Failure Reason: st2.actions.python.DeleteFabricConfig: DEBUG    Delete http://127.0.0.1:8888/v1/fabric with data {'fabric': 'no_fabric', 'key': 'loopback_port_number'}
Traceback (most recent call last):
  File "/opt/stackstorm/st2/local/lib/python2.7/site-packages/st2common/runners/python_action_wrapper.py", line 259, in <module>
    obj.run()
  File "/opt/stackstorm/st2/local/lib/python2.7/site-packages/st2common/runners/python_action_wrapper.py", line 155, in run
    output = action.run(**self._parameters)
  File "/opt/stackstorm/packs/network_inventory/actions/fabric_config_delete.py", line 28, in run
    return self._delete_fabric_config(fabric_name=fabric, key=key)
  File "/opt/stackstorm/packs/network_inventory/actions/fabric_config_delete.py", line 50, in _delete_fabric_config
    raise ValueError('Fabric: %s does not exist.' % fabric_name)
ValueError: Fabric: no_fabric does not exist.

Please run 'st2 execution get 59dc10eb4066ae3f06b840d4' to get details of failure
RC: 1
ERROR:
...
OUTPUT:

Operation failed:
Failure Reason: Failed to list the fabric details.  Messages:
Fabric does not exist: no_fabric

Please run 'st2 execution get 59dc10ee4066ae3f06b840d7' to get details of failure
ERR:

RC:
1
Fabric config for non-existent fabric                                 | PASS |
------------------------------------------------------------------------------
002 Verify User Defined Fabric                                        | PASS |
1 critical test, 1 passed, 0 failed
1 test total, 1 passed, 0 failed
==============================================================================