### PR TITLE
vf_cases

### DIFF
--- a/robotfm_tests/network_essentials_tests/004_One_NOS_Virtual_Fabric.rst
+++ b/robotfm_tests/network_essentials_tests/004_One_NOS_Virtual_Fabric.rst
@@ -9,30 +9,6 @@
         Log To Console   ${op}
         Should Contain   ${op}  Enabling VCS Virtual Fabric on the device 
 
-    GET NEXT AVAILABLE VF ID
-        ${result}=       Run Process  st2  run  network_essentials.get_next_available_network_id  mgmt_ip\=${SWITCH 1}
-        ${op}=           Get Variable Value  ${result.stdout}
-        Log To Console   ${op}
-        Should Not Contain   ${op}  network_id: '' 
-
-    GET NEXT AVAILABLE VF LENGTH
-        ${result}=       Run Process  st2  run  network_essentials.get_next_available_network_id  mgmt_ip\=${SWITCH 1}  length_of_the_range\=${VLAN LENGTH}
-        ${op}=           Get Variable Value  ${result.stdout}
-        Log To Console   ${op}
-        Should Not Contain   ${op}  network_id: '' 
-
-    GET NEXT AVAILABLE VF LENGTH RANGE
-        ${result}=       Run Process  st2  run  network_essentials.get_next_available_network_id  mgmt_ip\=${SWITCH 1}  length_of_the_range\=${VLAN RANGE}
-        ${op}=           Get Variable Value  ${result.stdout}
-        Log To Console   ${op}
-        Should Not Contain   ${op}  network_id: '' 
-
-    GET NEXT AVAILABLE VF INVALID LENGTH
-        ${result}=       Run Process  st2  run  network_essentials.get_next_available_network_id  mgmt_ip\=${SWITCH 1}  length_of_the_range\=${4096}
-        ${op}=           Get Variable Value  ${result.stdout}
-        Log To Console   ${op}
-        Should Contain   ${op}  ERROR 
-
     CREATE CTAG VLAN
         ${result}=       Run Process  st2  run  network_essentials.create_vlan  mgmt_ip\=${SWITCH 1}  vlan_id\=${FRESH VLAN ID}
         ${op}=           Get Variable Value  ${result.stdout}
@@ -83,12 +59,6 @@
 
     SWITCH PORT TRUNK RANGE
         ${result}=       Run Process  st2  run  network_essentials.create_switchport_trunk  mgmt_ip\=${SWITCH 1}  vlan_id\=${VF VLAN RANGE}  c_tag\=${VLAN RANGE}  intf_name\=${TRUNK INTF NAME}  intf_type\=tengigabitethernet
-        ${op}=           Get Variable Value  ${result.stdout}
-        Log To Console   ${op}
-        Should Contain   ${op}  ${SWITCHPORT_SUCCESS_MSG}
-
-    REMOVE SWITCH PORT TRUNK VLAN RANGE
-        ${result}=       Run Process  st2  run  network_essentials.remove_switchport_trunk_allowed_vlan  mgmt_ip\=${SWITCH 1}  vlan_id\=${VF VLAN RANGE}  c_tag\=${VLAN RANGE}  intf_name\=${TRUNK INTF NAME}  intf_type\=tengigabitethernet
         ${op}=           Get Variable Value  ${result.stdout}
         Log To Console   ${op}
         Should Contain   ${op}  ${SWITCHPORT_SUCCESS_MSG}


### PR DESCRIPTION
(robot)root@ubuntu:/home/uday/bwc-tests/robotfm_tests# robot network_essentials_tests/004_One_NOS_Virtual_Fabric.rst
==============================================================================
004 One NOS Virtual Fabric
==============================================================================
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Suite setup and Teardown: Cleaning Switches!!!
Return Code: 0
all output:
============================== 10.20.238.106 ==============================
setup_teardown/NOS_switch_configs/004_One_NOS_Virtual_Fabric_10_20_238_106.config
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
CONFIGURE VF Enable                                                   ..........
id: 5a01a2681d41c805b770aec8
status: succeeded
parameters:
  mgmt_ip: 10.20.238.106
  virtual_fabric_enable: true
result:
  exit_code: 0
  result:
    pre_check: true
    virtual_fabric_enable: true
  stderr: 'st2.actions.python.VirtualFabric: INFO     successfully connected to 10.20.238.106 to Configure VCS Virtual Fabric  on the device

    st2.actions.python.VirtualFabric: INFO     Enabling VCS Virtual Fabric on the device

    st2.actions.python.VirtualFabric: INFO     Closing connection to 10.20.238.106 after Configuring VCS Virtual Fabric on the device -- all done!

    '
  stdout: ''
CONFIGURE VF Enable                                                   | PASS |
------------------------------------------------------------------------------
CREATE CTAG VLAN                                                      .........
id: 5a01a2791d41c805b770aecb
status: succeeded
parameters:
  mgmt_ip: 10.20.238.106
  vlan_id: '450'
result:
  exit_code: 0
  result:
    vlan: true
  stderr: 'st2.actions.python.CreateVlan: INFO     Successfully connected to 10.20.238.106 to create interface vlans

    st2.actions.python.CreateVlan: INFO     Creating Vlans

    st2.actions.python.CreateVlan: INFO     Closing connection to 10.20.238.106 after creating vlan -- all done!

    '
  stdout: ''
CREATE CTAG VLAN                                                      | PASS |
------------------------------------------------------------------------------
CREATE VF VLAN                                                        .........
id: 5a01a2881d41c805b770aece
status: succeeded
parameters:
  mgmt_ip: 10.20.238.106
  vlan_id: '4500'
result:
  exit_code: 0
  result:
    vlan: true
  stderr: 'st2.actions.python.CreateVlan: INFO     Successfully connected to 10.20.238.106 to create interface vlans

    st2.actions.python.CreateVlan: INFO     Creating Vlans

    st2.actions.python.CreateVlan: INFO     Closing connection to 10.20.238.106 after creating vlan -- all done!

    '
  stdout: ''
CREATE VF VLAN                                                        | PASS |
------------------------------------------------------------------------------
SWITCH PORT TRUNK                                                     ...............
id: 5a01a2971d41c805b770aed1
status: succeeded
parameters:
  c_tag: '450'
  intf_name: 3/0/18
  intf_type: tengigabitethernet
  mgmt_ip: 10.20.238.106
  vlan_id: '4500'
result:
  exit_code: 0
  result:
    L2_interface_check: true
    disable_fabric_trunk: true
    disable_isl: true
    switchport_doesnot_exists: true
    switchport_trunk_config: true
  stderr: 'st2.actions.python.CreateSwitchPort: INFO     successfully connected to 10.20.238.106 to create switchport on Interface

    st2.actions.python.CreateSwitchPort: INFO     Interface is L2 interface.

    st2.actions.python.CreateSwitchPort: INFO     disabling isl on tengigabitethernet 3/0/18

    st2.actions.python.CreateSwitchPort: INFO     disabling fabric trunk on tengigabitethernet 3/0/18

    st2.actions.python.CreateSwitchPort: INFO     Configuring Switch port trunk

    st2.actions.python.CreateSwitchPort: INFO     closing connection to 10.20.238.106 after configuring switch port on interface -- all done!

    '
  stdout: ''
SWITCH PORT TRUNK                                                     | PASS |
------------------------------------------------------------------------------
REMOVE SWITCH PORT TRUNK VLAN                                         ...........
id: 5a01a2b21d41c805b770aed4
status: succeeded
parameters:
  c_tag: '450'
  intf_name: 3/0/18
  intf_type: tengigabitethernet
  mgmt_ip: 10.20.238.106
  vlan_id: '4500'
result:
  exit_code: 0
  result:
    Interface_Present: true
    switchport_doesnot_exists: true
    switchport_trunk_config: true
  stderr: 'st2.actions.python.RemoveSwitchPort: INFO     successfully connected to 10.20.238.106 to Remove switchport trunk allowed vlan on the Interface

    st2.actions.python.RemoveSwitchPort: INFO     Removing Switch port trunk allowed vlan 4500

    st2.actions.python.RemoveSwitchPort: INFO     closing connection to 10.20.238.106 after Removing the switch port trunk allowed vlan on interface -- all done!

    '
  stdout: ''
REMOVE SWITCH PORT TRUNK VLAN                                         | PASS |
------------------------------------------------------------------------------
SWITCH PORT TRUNK INVALID VLANS                                       .........
id: 5a01a2c51d41c805b770aed7
status: failed
parameters:
  c_tag: '4500'
  intf_name: 3/0/18
  intf_type: tengigabitethernet
  mgmt_ip: 10.20.238.106
  vlan_id: '450'
result:
  exit_code: 1
  result: None
  stderr: "st2.actions.python.CreateSwitchPort: INFO     successfully connected to 10.20.238.106 to create switchport on Interface\nst2.actions.python.CreateSwitchPort: ERROR    Vlans in vlan_id 450 must be in range(4096,8191)\nst2.actions.python.CreateSwitchPort: ERROR    Error encountered on 10.20.238.106 due to Vlans in vlan_id must be in range(4096,8191)\nTraceback (most recent call last):\n  File \"/opt/stackstorm/packs/network_essentials/actions/ne_base.py\", line 845, in wrapper\n    return func(*args, **kwds)\n  File \"/opt/stackstorm/packs/network_essentials/actions/create_switchport_trunk.py\", line 56, in switch_operation\n    device, intf_type, intf_name, vlan_action, vlan_num, c_tag)\n  File \"/opt/stackstorm/packs/network_essentials/actions/create_switchport_trunk.py\", line 134, in _check_interface_presence\n    raise ValueError('Vlans in vlan_id must be in range(4096,8191)')\nValueError: Vlans in vlan_id must be in range(4096,8191)\nTraceback (most recent call last):\n  File \"/opt/stackstorm/st2/local/lib/python2.7/site-packages/st2common/runners/python_action_wrapper.py\", line 259, in <module>\n    obj.run()\n  File \"/opt/stackstorm/st2/local/lib/python2.7/site-packages/st2common/runners/python_action_wrapper.py\", line 155, in run\n    output = action.run(**self._parameters)\n  File \"/opt/stackstorm/packs/network_essentials/actions/create_switchport_trunk.py\", line 37, in run\n    changes = self.switch_operation(intf_name, intf_type, vlan_id, c_tag)\n  File \"/opt/stackstorm/packs/network_essentials/actions/ne_base.py\", line 845, in wrapper\n    return func(*args, **kwds)\n  File \"/opt/stackstorm/packs/network_essentials/actions/create_switchport_trunk.py\", line 56, in switch_operation\n    device, intf_type, intf_name, vlan_action, vlan_num, c_tag)\n  File \"/opt/stackstorm/packs/network_essentials/actions/create_switchport_trunk.py\", line 134, in _check_interface_presence\n    raise ValueError('Vlans in vlan_id must be in range(4096,8191)')\nValueError: Vlans in vlan_id must be in range(4096,8191)\n"
  stdout: ''
SWITCH PORT TRUNK INVALID VLANS                                       | PASS |
------------------------------------------------------------------------------
DELETE SWITCH PORT                                                    ..........
id: 5a01a2d41d41c805b770aeda
status: succeeded
parameters:
  intf_name: 3/0/18
  intf_type: tengigabitethernet
  mgmt_ip: 10.20.238.106
result:
  exit_code: 0
  result:
    delete_switchport_intf: true
  stderr: 'st2.actions.python.DeleteSwitchport: INFO     successfully connected to 10.20.238.106 to Delete Switch Port on the interfaces on the device

    st2.actions.python.DeleteSwitchport: INFO     Deleting Switch Port on tengigabitethernet (u''3/0/18'',)

    st2.actions.python.DeleteSwitchport: INFO     Closing connection to 10.20.238.106 after Deleting Switchports on the interfaceon the device -- all done!

    '
  stdout: ''
DELETE SWITCH PORT                                                    | PASS |
------------------------------------------------------------------------------
CREATE CTAG VLAN RANGE                                                ............
id: 5a01a2e41d41c805b770aedd
status: succeeded
parameters:
  mgmt_ip: 10.20.238.106
  vlan_desc: test123
  vlan_id: 500-550
result:
  exit_code: 0
  result:
    vlan: true
  stderr: 'st2.actions.python.CreateVlan: INFO     Successfully connected to 10.20.238.106 to create interface vlans

    st2.actions.python.CreateVlan: INFO     Creating Vlans

    st2.actions.python.CreateVlan: INFO     Closing connection to 10.20.238.106 after creating vlan -- all done!

    '
  stdout: ''
CREATE CTAG VLAN RANGE                                                | PASS |
------------------------------------------------------------------------------
CREATE VF VLAN RANGE                                                  ............
id: 5a01a2f91d41c805b770aee0
status: succeeded
parameters:
  mgmt_ip: 10.20.238.106
  vlan_desc: test123
  vlan_id: 5000-5050
result:
  exit_code: 0
  result:
    vlan: true
  stderr: 'st2.actions.python.CreateVlan: INFO     Successfully connected to 10.20.238.106 to create interface vlans

    st2.actions.python.CreateVlan: INFO     Creating Vlans

    st2.actions.python.CreateVlan: INFO     Closing connection to 10.20.238.106 after creating vlan -- all done!

    '
  stdout: ''
CREATE VF VLAN RANGE                                                  | PASS |
------------------------------------------------------------------------------
SWITCH PORT TRUNK RANGE                                               ..........................................
id: 5a01a30e1d41c805b770aee3
status: succeeded
parameters:
  c_tag: 500-550
  intf_name: 3/0/18
  intf_type: tengigabitethernet
  mgmt_ip: 10.20.238.106
  vlan_id: 5000-5050
result:
  exit_code: 0
  result:
    L2_interface_check: true
    disable_fabric_trunk: true
    disable_isl: true
    switchport_doesnot_exists: true
    switchport_trunk_config: true
  stderr: 'st2.actions.python.CreateSwitchPort: INFO     successfully connected to 10.20.238.106 to create switchport on Interface

    st2.actions.python.CreateSwitchPort: INFO     Interface is L2 interface.

    st2.actions.python.CreateSwitchPort: INFO     disabling isl on tengigabitethernet 3/0/18

    st2.actions.python.CreateSwitchPort: INFO     disabling fabric trunk on tengigabitethernet 3/0/18

    st2.actions.python.CreateSwitchPort: INFO     Configuring Switch port trunk

    st2.actions.python.CreateSwitchPort: INFO     closing connection to 10.20.238.106 after configuring switch port on interface -- all done!

    '
  stdout: ''
SWITCH PORT TRUNK RANGE                                               | PASS |
------------------------------------------------------------------------------
[ WARN ] Multiple test cases with name 'DELETE SWITCH PORT' executed in test suite '004 One NOS Virtual Fabric'.
DELETE SWITCH PORT                                                    ..........
id: 5a01a3601d41c805b770aee6
status: succeeded
parameters:
  intf_name: 3/0/18
  intf_type: tengigabitethernet
  mgmt_ip: 10.20.238.106
result:
  exit_code: 0
  result:
    delete_switchport_intf: true
  stderr: 'st2.actions.python.DeleteSwitchport: INFO     successfully connected to 10.20.238.106 to Delete Switch Port on the interfaces on the device

    st2.actions.python.DeleteSwitchport: INFO     Deleting Switch Port on tengigabitethernet (u''3/0/18'',)

    st2.actions.python.DeleteSwitchport: INFO     Closing connection to 10.20.238.106 after Deleting Switchports on the interfaceon the device -- all done!

    '
  stdout: ''
DELETE SWITCH PORT                                                    | PASS |
------------------------------------------------------------------------------
CREATE MAC GROUP                                                      .........
id: 5a01a3711d41c805b770aee9
status: succeeded
parameters:
  mac_address:
  - 0a10.1122.3344
  mac_group_id: 11
  mgmt_ip: 10.20.238.106
result:
  exit_code: 0
  result:
    configure_entry_macs: true
    configure_mac_group: true
    pre_check_group: true
  stderr: "st2.actions.python.ConfigureMacGroup: INFO     successfully connected to 10.20.238.106 to Configure Mac Group on the device\nst2.actions.python.ConfigureMacGroup: INFO     Configuring Mac Group 11\nst2.actions.python.ConfigureMacGroup: INFO     Configuring Entry Mac Address [u'0a10.1122.3344'] for Mac Group 11 \nst2.actions.python.ConfigureMacGroup: INFO     Closing connection to 10.20.238.106 after Configuring Mac Groupon the device -- all done!\n"
  stdout: ''
CREATE MAC GROUP                                                      | PASS |
------------------------------------------------------------------------------
CONFIGURE SWITCH PORT ACCESS VLAN MAC CLASSIFICATION                  ...............
id: 5a01a3801d41c805b770aeec
status: succeeded
parameters:
  intf_name: 3/0/18
  intf_type: tengigabitethernet
  mac_group_id:
  - 11
  mgmt_ip: 10.20.238.106
  vlan_id: '450'
result:
  exit_code: 0
  result:
    L2_interface_check: true
    disable_fabric_trunk: true
    disable_isl: true
    mac_groups: true
    switchport_doesnot_exists: true
    vlan_exist: null
  stderr: "st2.actions.python.CreateSwitchPort: INFO     successfully connected to 10.20.238.106 to create switchport on Interface\nst2.actions.python.CreateSwitchPort: INFO     Interface is L2 interface.\nst2.actions.python.CreateSwitchPort: INFO     Disabling ISL on tengigabitethernet 3/0/18\nst2.actions.python.CreateSwitchPort: INFO     Disabling fabric trunk on tengigabitethernet 3/0/18\nst2.actions.python.CreateSwitchPort: INFO     Configuring Switchport Access Vlan and Associating the Mac Groups [(u'450', '11')] \nst2.actions.python.CreateSwitchPort: INFO     closing connection to 10.20.238.106 after configuring switch port on interface -- all done!\n"
  stdout: ''
CONFIGURE SWITCH PORT ACCESS VLAN MAC CLASSIFICATION                  | PASS |
------------------------------------------------------------------------------
CONFIGURE SWITCH PORT ACCESS VLAN MAC CLASSIFICATION INVALID          ...........
id: 5a01a39b1d41c805b770aeef
status: failed
parameters:
  intf_name: 3/0/18
  intf_type: tengigabitethernet
  mac_group_id:
  - 11
  mgmt_ip: 10.20.238.106
  vlan_id: '4500'
result:
  exit_code: 1
  result: None
  stderr: "st2.actions.python.CreateSwitchPort: INFO     successfully connected to 10.20.238.106 to create switchport on Interface\nst2.actions.python.CreateSwitchPort: INFO     Interface is L2 interface.\nst2.actions.python.CreateSwitchPort: ERROR    Mac Group 11 is already used with a different vlan_id 450\nTraceback (most recent call last):\n  File \"/opt/stackstorm/st2/local/lib/python2.7/site-packages/st2common/runners/python_action_wrapper.py\", line 259, in <module>\n    obj.run()\n  File \"/opt/stackstorm/st2/local/lib/python2.7/site-packages/st2common/runners/python_action_wrapper.py\", line 155, in run\n    output = action.run(**self._parameters)\n  File \"/opt/stackstorm/packs/network_essentials/actions/create_switchport_access.py\", line 56, in run\n    device, intf_type, intf_name, vlan_id, mac_address, mac_group_id)\n  File \"/opt/stackstorm/packs/network_essentials/actions/create_switchport_access.py\", line 198, in _check_requirements_switchport_exists\n    raise ValueError('Fetching switch port mode failed %s', str(e))\nValueError: ('Fetching switch port mode failed %s', 'Mac Group is already used with a different Vlan')\n"
  stdout: ''
CONFIGURE SWITCH PORT ACCESS VLAN MAC CLASSIFICATION INVALID          | PASS |
------------------------------------------------------------------------------
[ WARN ] Multiple test cases with name 'DELETE SWITCH PORT' executed in test suite '004 One NOS Virtual Fabric'.
DELETE SWITCH PORT                                                    ..........
id: 5a01a3ae1d41c805b770aef2
status: succeeded
parameters:
  intf_name: 3/0/18
  intf_type: tengigabitethernet
  mgmt_ip: 10.20.238.106
result:
  exit_code: 0
  result:
    delete_switchport_intf: true
  stderr: 'st2.actions.python.DeleteSwitchport: INFO     successfully connected to 10.20.238.106 to Delete Switch Port on the interfaces on the device

    st2.actions.python.DeleteSwitchport: INFO     Deleting Switch Port on tengigabitethernet (u''3/0/18'',)

    st2.actions.python.DeleteSwitchport: INFO     Closing connection to 10.20.238.106 after Deleting Switchports on the interfaceon the device -- all done!

    '
  stdout: ''
DELETE SWITCH PORT                                                    | PASS |
------------------------------------------------------------------------------
CONFIGURE VLAN TO VNI MAPPING                                         .......
id: 5a01a3bf1d41c805b770aef5
status: succeeded
parameters:
  mgmt_ip: 10.20.238.106
  vlan_id: '450'
  vlan_vni: '450'
result:
  exit_code: 0
  result:
    vlan_vni_mapping: true
  stderr: 'st2.actions.python.ConfigureVni: INFO     successfully connected to 10.20.238.106 to Configure VNI mapping under overlay gateway on the device

    st2.actions.python.ConfigureVni: INFO     Configuring vlan 450 to vni 450 mapping under overlay gateway test

    st2.actions.python.ConfigureVni: INFO     Closing connection to 10.20.238.106 after Configuring VNI mapping under overlay gateway on the device -- all done!

    '
  stdout: ''
CONFIGURE VLAN TO VNI MAPPING                                         | PASS |
------------------------------------------------------------------------------
CONFIGURE VLAN TO VNI RANGE MAPPING                                   ..................
id: 5a01a3ca1d41c805b770aef8
status: succeeded
parameters:
  mgmt_ip: 10.20.238.106
  vlan_id: 500-550
  vlan_vni: 5000-5050
result:
  exit_code: 0
  result:
    vlan_vni_mapping: true
  stderr: 'st2.actions.python.ConfigureVni: INFO     successfully connected to 10.20.238.106 to Configure VNI mapping under overlay gateway on the device

    st2.actions.python.ConfigureVni: INFO     Configuring vlan 500-550 to vni 5000-5050 mapping under overlay gateway test

    st2.actions.python.ConfigureVni: INFO     Closing connection to 10.20.238.106 after Configuring VNI mapping under overlay gateway on the device -- all done!

    '
  stdout: ''
CONFIGURE VLAN TO VNI RANGE MAPPING                                   | PASS |
------------------------------------------------------------------------------
DELETE VLAN TO VNI MAPPING                                            ......
id: 5a01a3eb1d41c805b770aefb
status: succeeded
parameters:
  mgmt_ip: 10.20.238.106
  vlan_id: '450'
result:
  exit_code: 0
  result:
    vlan_vni_mapping: true
  stderr: 'st2.actions.python.DeleteVlanVni: INFO     Successfully connected to 10.20.238.106 to Delete VLAN to VNI mapping under overlay gateway on the device

    st2.actions.python.DeleteVlanVni: INFO     Deleting vlan 450 mapping under overlay gateway test

    st2.actions.python.DeleteVlanVni: INFO     Closing connection to 10.20.238.106 after Delete VLAN to VNI mapping under overlay gateway on the device -- all done!

    '
  stdout: ''
DELETE VLAN TO VNI MAPPING                                            | PASS |
------------------------------------------------------------------------------
DELETE VLAN TO VNI RANGE MAPPING                                      ...............
id: 5a01a3f41d41c805b770aefe
status: succeeded
parameters:
  mgmt_ip: 10.20.238.106
  vlan_id: 500-550
result:
  exit_code: 0
  result:
    vlan_vni_mapping: true
  stderr: 'st2.actions.python.DeleteVlanVni: INFO     Successfully connected to 10.20.238.106 to Delete VLAN to VNI mapping under overlay gateway on the device

    st2.actions.python.DeleteVlanVni: INFO     Deleting vlan 500-550 mapping under overlay gateway test

    st2.actions.python.DeleteVlanVni: INFO     Closing connection to 10.20.238.106 after Delete VLAN to VNI mapping under overlay gateway on the device -- all done!

    '
  stdout: ''
DELETE VLAN TO VNI RANGE MAPPING                                      | PASS |
------------------------------------------------------------------------------
DELETE VLAN TO VNI AUTO MAPPING                                       ......
id: 5a01a40f1d41c805b770af01
status: succeeded
parameters:
  auto: true
  mgmt_ip: 10.20.238.106
result:
  exit_code: 0
  result:
    vlan_vni_mapping: true
  stderr: 'st2.actions.python.DeleteVlanVni: INFO     Successfully connected to 10.20.238.106 to Delete VLAN to VNI mapping under overlay gateway on the device

    st2.actions.python.DeleteVlanVni: INFO     Deleting auto vlan to vni mapping under overlay gateway test

    st2.actions.python.DeleteVlanVni: INFO     Closing connection to 10.20.238.106 after Delete VLAN to VNI mapping under overlay gateway on the device -- all done!

    '
  stdout: ''
DELETE VLAN TO VNI AUTO MAPPING                                       | PASS |
------------------------------------------------------------------------------
DELETE CTAG VLAN                                                      .........
id: 5a01a4181d41c805b770af04
status: succeeded
parameters:
  mgmt_ip: 10.20.238.106
  vlan_id: '450'
result:
  exit_code: 0
  result:
    vlan: true
  stderr: 'st2.actions.python.DeleteVlan: INFO     Successfully connected to 10.20.238.106 to delete interface vlans

    st2.actions.python.DeleteVlan: INFO     Deleting Vlans 450

    st2.actions.python.DeleteVlan: INFO     Closing connection to 10.20.238.106 after Deleting vlans -- all done!

    '
  stdout: ''
DELETE CTAG VLAN                                                      | PASS |
------------------------------------------------------------------------------
DELETE VF VLAN                                                        .........
id: 5a01a4261d41c805b770af07
status: succeeded
parameters:
  mgmt_ip: 10.20.238.106
  vlan_id: '4500'
result:
  exit_code: 0
  result:
    vlan: true
  stderr: 'st2.actions.python.DeleteVlan: INFO     Successfully connected to 10.20.238.106 to delete interface vlans

    st2.actions.python.DeleteVlan: INFO     Deleting Vlans 4500

    st2.actions.python.DeleteVlan: INFO     Closing connection to 10.20.238.106 after Deleting vlans -- all done!

    '
  stdout: ''
DELETE VF VLAN                                                        | PASS |
------------------------------------------------------------------------------
DELETE CTAG VLAN RANGE                                                ....................................
id: 5a01a4351d41c805b770af0a
status: succeeded
parameters:
  mgmt_ip: 10.20.238.106
  vlan_id: 500-550
result:
  exit_code: 0
  result:
    vlan: true
  stderr: 'st2.actions.python.DeleteVlan: INFO     Successfully connected to 10.20.238.106 to delete interface vlans

    st2.actions.python.DeleteVlan: INFO     Deleting Vlans 500-550

    st2.actions.python.DeleteVlan: INFO     Closing connection to 10.20.238.106 after Deleting vlans -- all done!

    '
  stdout: ''
DELETE CTAG VLAN RANGE                                                | PASS |
------------------------------------------------------------------------------
DELETE VF VLAN RANGE                                                  .......................................
id: 5a01a47b1d41c805b770af0d
status: succeeded
parameters:
  mgmt_ip: 10.20.238.106
  vlan_id: 5000-5050
result:
  exit_code: 0
  result:
    vlan: true
  stderr: 'st2.actions.python.DeleteVlan: INFO     Successfully connected to 10.20.238.106 to delete interface vlans

    st2.actions.python.DeleteVlan: INFO     Deleting Vlans 5000-5050

    st2.actions.python.DeleteVlan: INFO     Closing connection to 10.20.238.106 after Deleting vlans -- all done!

    '
  stdout: ''
DELETE VF VLAN RANGE                                                  | PASS |
------------------------------------------------------------------------------
CONFIGURE VF Disable                                                  .........
id: 5a01a4c61d41c805b770af10
status: succeeded
parameters:
  mgmt_ip: 10.20.238.106
  virtual_fabric_enable: false
result:
  exit_code: 0
  result:
    pre_check: true
    virtual_fabric_enable: true
  stderr: 'st2.actions.python.VirtualFabric: INFO     successfully connected to 10.20.238.106 to Configure VCS Virtual Fabric  on the device

    st2.actions.python.VirtualFabric: INFO     Disabling VCS Virtual Fabric on the device

    st2.actions.python.VirtualFabric: INFO     Closing connection to 10.20.238.106 after Configuring VCS Virtual Fabric on the device -- all done!

    '
  stdout: ''
CONFIGURE VF Disable                                                  | PASS |
------------------------------------------------------------------------------
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Suite setup and Teardown: Cleaning Switches!!!
Return Code: 0
all output:
============================== 10.20.238.106 ==============================
setup_teardown/NOS_switch_configs/004_One_NOS_Virtual_Fabric_10_20_238_106.config
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
004 One NOS Virtual Fabric                                            | PASS |
25 critical tests, 25 passed, 0 failed
25 tests total, 25 passed, 0 failed
==============================================================================
Output:  /home/uday/bwc-tests/robotfm_tests/output.xml
Log:     /home/uday/bwc-tests/robotfm_tests/log.html
Report:  /home/uday/bwc-tests/robotfm_tests/report.html
