### PR TITLE
Removing this check, since it fails for stable builds. We will add this

### DIFF
--- a/robotfm_tests/bwc_cli_tests/002_Verify_User_Defined_Fabric.rst
+++ b/robotfm_tests/bwc_cli_tests/002_Verify_User_Defined_Fabric.rst
@@ -110,7 +110,6 @@
         leaf_asn_block        ${UNNUMBERED SPINE ASN}      ${UNNUMBERED FABRIC}  ${OPERATION FAILED}
         spine_asn_block       ${SINGLE LEAF ASN}           ${SINGLE FABRIC}      ${OPERATION FAILED}
         leaf_asn_block        ${SINGLE SPINE ASN}          ${SINGLE FABRIC}      ${OPERATION FAILED}
-        mct_link_ip_range     ${SINGLE MCT IP}             ${SINGLE FABRIC}      ${OPERATION FAILED}
 
 
     Switch registration should be successful now for all three fabrics "new_fabric", "${UNNUMBERED P2P IP}", "single_asn_fabric":


### PR DESCRIPTION
check for stable builds after GA