### PR TITLE
Included NE device registration testsuite in a new directory

### DIFF
--- a/robotfm_tests/network_essentials_device_registration/001_Device_Registration_Network_Essentials.rst
+++ b/robotfm_tests/network_essentials_device_registration/001_Device_Registration_Network_Essentials.rst
@@ -1,0 +1,39 @@
+.. code:: robotframework
+
+
+    *** Test Cases ***
+
+    REGISTER CASTOR
+        [Tags]           skip-stable
+        ${result}=       Run Process  st2  run  network_essentials.register_device_credentials  mgmt_ip\=${CASTOR_IP}  username\=${CASTOR_USERNAME}  password\=${CASTOR_PASSWORD}
+        ${op}=           Get Variable Value  ${result.stdout}
+        Log To Console   ${op}
+        Should Not Contain   ${op}  ERROR
+
+    REGISTER FREEDOM
+        [Tags]           skip-stable
+        ${result}=       Run Process  st2  run  network_essentials.register_device_credentials  mgmt_ip\=${FREEDOM_IP}  username\=${FREEDOM_USERNAME}  password\=${FREEDOM_PASSWORD}
+        ${op}=           Get Variable Value  ${result.stdout}
+        Log To Console   ${op}
+        Should Not Contain   ${op}  ERROR
+
+    REGISTER CEDAR
+        [Tags]           skip-stable
+        ${result}=       Run Process  st2  run  network_essentials.register_device_credentials  mgmt_ip\=${CEDAR_IP}  username\=${CEDAR_USERNAME}  password\=${CEDAR_PASSWORD}
+        ${op}=           Get Variable Value  ${result.stdout}
+        Log To Console   ${op}
+        Should Not Contain   ${op}  ERROR
+
+    REGISTER USER DEFAULT
+        [Tags]           skip-stable
+        ${result}=       Run Process  st2  run  network_essentials.register_device_credentials  mgmt_ip\=${DEFAULT_IP}  username\=${DEFAULT_USERNAME}  password\=${DEFAULT_PASSWORD}
+        ${op}=           Get Variable Value  ${result.stdout}
+        Log To Console   ${op}
+        Should Not Contain   ${op}  ERROR
+
+
+    *** Settings ***
+    Library             OperatingSystem
+    Library             Process
+    Resource            ../resource.robot
+    Variables           001_Device_Registration_Network_Essentials.yaml

--- a/robotfm_tests/network_essentials_device_registration/001_Device_Registration_Network_Essentials.yaml
+++ b/robotfm_tests/network_essentials_device_registration/001_Device_Registration_Network_Essentials.yaml
@@ -1,0 +1,15 @@
+CASTOR_IP:             "10.20.238.106"
+CASTOR_USERNAME:       "admin"
+CASTOR_PASSWORD:       "password"
+
+FREEDOM_IP:            "10.24.39.254"
+FREEDOM_USERNAME:      "admin"
+FREEDOM_PASSWORD:      "password"
+
+CEDAR_IP:              "10.24.39.251"
+CEDAR_USERNAME:        "admin"
+CEDAR_PASSWORD:        "password"
+
+DEFAULT_IP:            "USER.DEFAULT"
+DEFAULT_USERNAME:      "admin"
+DEFAULT_PASSWORD:      "password"


### PR DESCRIPTION
Created a new directory: network_essentials_device_registration
under robotfm_tests and added the device registration specific
test files here.