### PR TITLE
Fix ACL CI test cases 

### DIFF
--- a/robotfm_tests/network_essentials_acl_tests/001_Castor_Workflows.rst
+++ b/robotfm_tests/network_essentials_acl_tests/001_Castor_Workflows.rst
@@ -4,7 +4,6 @@
     *** Test Cases ***
     
     CREATE AND APPLY DROP PROVISION L2 RULE WITH ANY SOURCE DESTINATION
-        [Tags]           skip-unstable
         ${result}=       Run Process  st2  run  network_essentials.drop_provision  mgmt_ip\=${CASTOR_IP}  username\=${USERNAME}  password\=${PASSWORD}  acl_name\=${MAC_ACL_NAME}  intf_type\=${VDX INT TYPE}  intf_name\=${VDX INT NAME2}  intf\=${VDX INT NAME2}  address_type\=${MAC_ADDR_TYPE}  rule_action\=${ACTION}  source\=${SOURCE5}  seq_id\=${SEQ_ID1}  
         Log To Console   ${result.stdout}
 	${status}=     Get Lines Containing String  ${result.stdout}  status
@@ -13,7 +12,6 @@
 	Should Be True		${res}
 
     CREATE AND APPLY DROP PROVISION L2 RULE WITH ETHERTYPE AND ANY SOURCE DESTINATION
-        [Tags]           skip-unstable
         ${result}=       Run Process  st2  run  network_essentials.drop_provision  mgmt_ip\=${CASTOR_IP}  username\=${USERNAME}  password\=${PASSWORD}  acl_name\=${MAC_ACL_NAME}  intf_type\=${VDX INT TYPE}  intf_name\=${VDX INT NAME2}  intf\=${VDX INT NAME2}  address_type\=${MAC_ADDR_TYPE}  rule_action\=${ACTION}  source\=${SOURCE5}  destination\=${DEST5}  seq_id\=${SEQ_ID2}  ethertype\=${ETHERTYPE3}
         Log To Console   ${result.stdout}
 	${status}=     Get Lines Containing String  ${result.stdout}  status
@@ -22,7 +20,6 @@
 	Should Be True		${res}
 
     CREATE AND APPLY DROP PROVISION L2 RULE WITH SOURCE_MAC AND DESTINATION
-        [Tags]           skip-unstable
         ${result}=       Run Process  st2  run  network_essentials.drop_provision  mgmt_ip\=${CASTOR_IP}  username\=${USERNAME}  password\=${PASSWORD}  acl_name\=${MAC_ACL_NAME1}  intf_type\=${VDX INT TYPE}  intf_name\=${VDX INT NAME3}  intf\=${VDX INT NAME3}  address_type\=${MAC_ADDR_TYPE}  rule_action\=${ACTION}  source\=${SOURCE1}  src_mac_addr_mask\=${SRC_MAC_ADDR_MASK1}  seq_id\=${SEQ_ID3}  ethertype\=${ETHERTYPE2}
         Log To Console   ${result.stdout}
 	${status}=     Get Lines Containing String  ${result.stdout}  status
@@ -31,7 +28,6 @@
 	Should Be True		${res}
 
     CREATE AND APPLY DROP PROVISION L2 RULE WITH SOURCE_MAC, SRC_MAC_MASK AND DESTINATION
-        [Tags]           skip-unstable
         ${result}=       Run Process  st2  run  network_essentials.drop_provision  mgmt_ip\=${CASTOR_IP}  username\=${USERNAME}  password\=${PASSWORD}  acl_name\=${MAC_ACL_NAME}  intf_type\=${VDX INT TYPE}  intf_name\=${VDX INT NAME2}  intf\=${VDX INT NAME2}  address_type\=${MAC_ADDR_TYPE}  rule_action\=${ACTION}  source\=${SOURCE1}  src_mac_addr_mask\=${SRC_MAC_ADDR_MASK}  seq_id\=${SEQ_ID4}  
         Log To Console   ${result.stdout}
 	${status}=     Get Lines Containing String  ${result.stdout}  status
@@ -40,7 +36,6 @@
 	Should Be True		${res}
 
     CREATE AND APPLY DROP PROVISION L2 RULE WITH SOURCE_MAC, DESTINATION_MAC AND VLAN
-        [Tags]           skip-unstable
         ${result}=       Run Process  st2  run  network_essentials.drop_provision  mgmt_ip\=${CASTOR_IP}  username\=${USERNAME}  password\=${PASSWORD}  acl_name\=${MAC_ACL_NAME2}  intf_type\=${VDX INT TYPE}  intf_name\=${VDX INT NAME4}  intf\=${VDX INT NAME4}  address_type\=${MAC_ADDR_TYPE}  rule_action\=${ACTION}  source\=${SOURCE1}  src_mac_addr_mask\=${SRC_MAC_ADDR_MASK1}  destination\=${DEST1}  dst_mac_addr_mask\=${DEST_MAC_ADDR_MASK3}  seq_id\=${SEQ_ID5}  ethertype\=${ETHERTYPE2}  vlan_id\=${VLAN ID7}
         Log To Console   ${result.stdout}
 	${status}=     Get Lines Containing String  ${result.stdout}  status
@@ -49,7 +44,6 @@
 	Should Be True		${res}
 
     CREATE AND APPLY DROP PROVISION L2 RULE WITH DESTINATION_MAC AND VLAN
-        [Tags]           skip-unstable
         ${result}=       Run Process  st2  run  network_essentials.drop_provision  mgmt_ip\=${CASTOR_IP}  username\=${USERNAME}  password\=${PASSWORD}  acl_name\=${MAC_ACL_NAME}  intf_type\=${VDX INT TYPE}  intf_name\=${VDX INT NAME2}  intf\=${VDX INT NAME2}  address_type\=${MAC_ADDR_TYPE}  rule_action\=${ACTION}  source\=${SOURCE5}  destination\=${DEST2}  dst_mac_addr_mask\=${DEST_MAC_ADDR_MASK3}  seq_id\=${SEQ_ID6}  ethertype\=${ETHERTYPE2}  vlan_id\=${VLAN ID5}
         Log To Console   ${result.stdout}
 	${status}=     Get Lines Containing String  ${result.stdout}  status
@@ -58,7 +52,6 @@
 	Should Be True		${res}
 
     CREATE AND APPLY DROP PROVISION L2 RULE WITH ANY SOURCE, DESTINATION_MAC AND VLAN
-        [Tags]           skip-unstable
         ${result}=       Run Process  st2  run  network_essentials.drop_provision  mgmt_ip\=${CASTOR_IP}  username\=${USERNAME}  password\=${PASSWORD}  acl_name\=${MAC_ACL_NAME}  intf_type\=${VDX INT TYPE}  intf_name\=${VDX INT NAME2}  intf\=${VDX INT NAME2}  address_type\=${MAC_ADDR_TYPE}  rule_action\=${ACTION}  source\=${SOURCE5}  destination\=${DEST2}  dst_mac_addr_mask\=${DEST_MAC_ADDR_MASK2}  seq_id\=${SEQ_ID7}  ethertype\=${ETHERTYPE2}  vlan_id\=${VLAN ID6}
         Log To Console   ${result.stdout}
 	${status}=     Get Lines Containing String  ${result.stdout}  status
@@ -67,7 +60,6 @@
 	Should Be True		${res}
 
     NEGATIVE, DUPLICATE ENTRY, CREATE AND APPLY DROP PROVISION L2 RULE WITH ANY SOURCE, DESTINATION_MAC AND VLAN
-        [Tags]           skip-unstable
         ${result}=       Run Process  st2  run  network_essentials.drop_provision  mgmt_ip\=${CASTOR_IP}  username\=${USERNAME}  password\=${PASSWORD}  acl_name\=${MAC_ACL_NAME}  intf_type\=${VDX INT TYPE}  intf_name\=${VDX INT NAME2}  intf\=${VDX INT NAME2}  address_type\=${MAC_ADDR_TYPE}  rule_action\=${ACTION}  source\=${SOURCE5}  destination\=${DEST2}  dst_mac_addr_mask\=${DEST_MAC_ADDR_MASK2}  seq_id\=${SEQ_ID7}  ethertype\=${ETHERTYPE2}  vlan_id\=${VLAN ID6}
         Log To Console   ${result.stdout}
 	${status}=     Get Lines Containing String  ${result.stdout}  status
@@ -78,7 +70,6 @@
 
 
     CREATE AND APPLY DROP PROVISION IPv4 RULE WITH PROTOCOL AND ANY SOURCE DESTINATION
-        [Tags]           skip-unstable
         ${result}=       Run Process  st2  run  network_essentials.drop_provision  mgmt_ip\=${CASTOR_IP}  username\=${USERNAME}  password\=${PASSWORD}  acl_name\=${IPV4_ACL_NAME}  intf_type\=${VDX INT TYPE}  intf_name\=${VDX INT NAME2}  intf\=${VDX INT NAME2}  address_type\=${IPV4_ADDR_TYPE}  rule_action\=${ACTION}  source\=${SOURCEF}  destination\=${DESTF}  protocol_type\=${PROTOCOL_TYPE4}  ethertype\=${ETHERTYPE}  seq_id\=${SEQ_ID1}  
         Log To Console   ${result.stdout}
 	${status}=     Get Lines Containing String  ${result.stdout}  status
@@ -87,7 +78,6 @@
 	Should Be True		${res}
 
     CREATE AND APPLY DROP PROVISION IPv4 RULE WITH PROTOCOL AND DESTINATION
-        [Tags]           skip-unstable
         ${result}=       Run Process  st2  run  network_essentials.drop_provision  mgmt_ip\=${CASTOR_IP}  username\=${USERNAME}  password\=${PASSWORD}  acl_name\=${IPV4_ACL_NAME}  intf_type\=${VDX INT TYPE}  intf_name\=${VDX INT NAME2}  intf\=${VDX INT NAME2}  address_type\=${IPV4_ADDR_TYPE}  rule_action\=${ACTION}  source\=${SOURCEF}  destination\=${DESTA}  protocol_type\=${PROTOCOL_TYPE1}  ethertype\=${ETHERTYPE}  vlan_id\=${VLAN ID5}  seq_id\=${SEQ_ID2}  
         Log To Console   ${result.stdout}
 	${status}=     Get Lines Containing String  ${result.stdout}  status
@@ -96,7 +86,6 @@
 	Should Be True		${res}
 
     CREATE AND APPLY DROP PROVISION IPv4 RULE WITH PROTOCOL ICMP, SOURCE AND DESTINATION
-        [Tags]           skip-unstable
         ${result}=       Run Process  st2  run  network_essentials.drop_provision  mgmt_ip\=${CASTOR_IP}  username\=${USERNAME}  password\=${PASSWORD}  acl_name\=${IPV4_ACL_NAME1}  intf_type\=${VDX INT TYPE}  intf_name\=${VDX INT NAME3}  intf\=${VDX INT NAME3}  address_type\=${IPV4_ADDR_TYPE}  rule_action\=${ACTION}  source\=${SOURCEA}  destination\=${DESTA}  protocol_type\=${PROTOCOL_TYPE3}  seq_id\=${SEQ_ID3}  
         Log To Console   ${result.stdout}
 	${status}=     Get Lines Containing String  ${result.stdout}  status
@@ -105,7 +94,6 @@
 	Should Be True		${res}
 
     CREATE AND APPLY DROP PROVISION IPv4 RULE WITH PROTOCOL UDP, SOURCE AND DESTINATION
-        [Tags]           skip-unstable
         ${result}=       Run Process  st2  run  network_essentials.drop_provision  mgmt_ip\=${CASTOR_IP}  username\=${USERNAME}  password\=${PASSWORD}  acl_name\=${IPV4_ACL_NAME}  intf_type\=${VDX INT TYPE}  intf_name\=${VDX INT NAME2}  intf\=${VDX INT NAME2}  address_type\=${IPV4_ADDR_TYPE}  rule_action\=${ACTION}  source\=${SOURCEH}  destination\=${DESTA}  protocol_type\=${PROTOCOL_TYPE1}  ethertype\=${ETHERTYPE}  vlan_id\=${VLAN ID2}  seq_id\=${SEQ_ID4}  
         Log To Console   ${result.stdout}
 	${status}=     Get Lines Containing String  ${result.stdout}  status
@@ -114,7 +102,6 @@
 	Should Be True		${res}
 
     CREATE AND APPLY DROP PROVISION IPv4 RULE WITH PROTOCOL TCP, SOURCE AND DESTINATION
-        [Tags]           skip-unstable
         ${result}=       Run Process  st2  run  network_essentials.drop_provision  mgmt_ip\=${CASTOR_IP}  username\=${USERNAME}  password\=${PASSWORD}  acl_name\=${IPV4_ACL_NAME}  intf_type\=${VDX INT TYPE}  intf_name\=${VDX INT NAME2}  intf\=${VDX INT NAME2}  address_type\=${IPV4_ADDR_TYPE}  rule_action\=${ACTION}  source\=${SOURCEI}  destination\=${DESTB}  protocol_type\=${PROTOCOL_TYPE2}  seq_id\=${SEQ_ID5}  
         Log To Console   ${result.stdout}
 	${status}=     Get Lines Containing String  ${result.stdout}  status
@@ -123,7 +110,6 @@
 	Should Be True		${res}
 
     CREATE AND APPLY DROP PROVISION IPv4 RULE WITH PROTOCOL TCP, SOURCE DOMAIN AND DESTINATION
-        [Tags]           skip-unstable
         ${result}=       Run Process  st2  run  network_essentials.drop_provision  mgmt_ip\=${CASTOR_IP}  username\=${USERNAME}  password\=${PASSWORD}  acl_name\=${IPV4_ACL_NAME2}  intf_type\=${VDX INT TYPE}  intf_name\=${VDX INT NAME4}  intf\=${VDX INT NAME4}  address_type\=${IPV4_ADDR_TYPE}  rule_action\=${ACTION}  source\=${SOURCEI}  destination\=${DESTB}  protocol_type\=${PROTOCOL_TYPE2}  ethertype\=${ETHERTYPE3}  vlan_id\=${VLAN ID1}  seq_id\=${SEQ_ID6}  
         Log To Console   ${result.stdout}
 	${status}=     Get Lines Containing String  ${result.stdout}  status
@@ -132,7 +118,6 @@
 	Should Be True		${res}
 
     CREATE AND APPLY DROP PROVISION IPv4 RULE WITH PROTOCOL, DSCP, SOURCE AND DESTINATION
-        [Tags]           skip-unstable
         ${result}=       Run Process  st2  run  network_essentials.drop_provision  mgmt_ip\=${CASTOR_IP}  username\=${USERNAME}  password\=${PASSWORD}  acl_name\=${IPV4_ACL_NAME}  intf_type\=${VDX INT TYPE}  intf_name\=${VDX INT NAME2}  intf\=${VDX INT NAME2}  address_type\=${IPV4_ADDR_TYPE}  rule_action\=${ACTION}  source\=${SOURCEI}  destination\=${DESTB}  protocol_type\=${PROTOCOL_TYPE2}  dscp\=${DSCP2}  ethertype\=${ETHERTYPE}  vlan_id\=${VLAN ID3}  seq_id\=${SEQ_ID7}  
         Log To Console   ${result.stdout}
 	${status}=     Get Lines Containing String  ${result.stdout}  status
@@ -141,7 +126,6 @@
 	Should Be True		${res}
 
     CREATE AND APPLY DROP PROVISION IPv4 RULE WITH PROTOCOL UDP, DSCP, SOURCE NTP AND DESTINATION
-        [Tags]           skip-unstable
         ${result}=       Run Process  st2  run  network_essentials.drop_provision  mgmt_ip\=${CASTOR_IP}  username\=${USERNAME}  password\=${PASSWORD}  acl_name\=${IPV4_ACL_NAME1}  intf_type\=${VDX INT TYPE}  intf_name\=${VDX INT NAME3}  intf\=${VDX INT NAME3}  address_type\=${IPV4_ADDR_TYPE}  rule_action\=${ACTION}  source\=${SOURCEG}  destination\=${DESTC}  protocol_type\=${PROTOCOL_TYPE1}  dscp\=${DSCP1}  ethertype\=${ETHERTYPE}  vlan_id\=${VLAN ID4}  seq_id\=${SEQ_ID8}  
         Log To Console   ${result.stdout}
 	${status}=     Get Lines Containing String  ${result.stdout}  status
@@ -150,7 +134,6 @@
 	Should Be True		${res}
 
     CREATE AND APPLY DROP PROVISION IPv4 RULE WITH PROTOCOL UDP, DSCP, SOURCE CHARGEN AND DESTINATION
-        [Tags]           skip-unstable
         ${result}=       Run Process  st2  run  network_essentials.drop_provision  mgmt_ip\=${CASTOR_IP}  username\=${USERNAME}  password\=${PASSWORD}  acl_name\=${IPV4_ACL_NAME}  intf_type\=${VDX INT TYPE}  intf_name\=${VDX INT NAME2}  intf\=${VDX INT NAME2}  address_type\=${IPV4_ADDR_TYPE}  rule_action\=${ACTION}  source\=${SOURCEC}  destination\=${DESTH}  protocol_type\=${PROTOCOL_TYPE1}  dscp\=${DSCP4}  ethertype\=${ETHERTYPE}  vlan_id\=${VLAN ID5}  seq_id\=${SEQ_ID9}  
         Log To Console   ${result.stdout}
 	${status}=     Get Lines Containing String  ${result.stdout}  status
@@ -159,7 +142,6 @@
 	Should Be True		${res}
 
     CREATE AND APPLY DROP PROVISION IPv4 RULE WITH PROTOCOL UDP, DSCP, SOURCE SSDP AND DESTINATION
-        [Tags]           skip-unstable
         ${result}=       Run Process  st2  run  network_essentials.drop_provision  mgmt_ip\=${CASTOR_IP}  username\=${USERNAME}  password\=${PASSWORD}  acl_name\=${IPV4_ACL_NAME2}  intf_type\=${VDX INT TYPE}  intf_name\=${VDX INT NAME4}  intf\=${VDX INT NAME4}  address_type\=${IPV4_ADDR_TYPE}  rule_action\=${ACTION}  source\=${SOURCEE}  destination\=${DESTI}  protocol_type\=${PROTOCOL_TYPE1}  dscp\=${DSCP3}  ethertype\=${ETHERTYPE}  vlan_id\=${VLAN ID2}  seq_id\=${SEQ_ID10}  
         Log To Console   ${result.stdout}
 	${status}=     Get Lines Containing String  ${result.stdout}  status
@@ -168,7 +150,6 @@
 	Should Be True		${res}
 
     CREATE AND APPLY DROP PROVISION IPv4 RULE WITH PROTOCOL UDP, DSCP, SOURCE QOTD AND DESTINATION
-        [Tags]           skip-unstable
         ${result}=       Run Process  st2  run  network_essentials.drop_provision  mgmt_ip\=${CASTOR_IP}  username\=${USERNAME}  password\=${PASSWORD}  acl_name\=${IPV4_ACL_NAME}  intf_type\=${VDX INT TYPE}  intf_name\=${VDX INT NAME2}  intf\=${VDX INT NAME2}  address_type\=${IPV4_ADDR_TYPE}  rule_action\=${ACTION}  source\=${SOURCED}  destination\=${DESTI}  protocol_type\=${PROTOCOL_TYPE1}  dscp\=${DSCP1}  ethertype\=${ETHERTYPE}  vlan_id\=${VLAN ID3}  seq_id\=${SEQ_ID11}  
         Log To Console   ${result.stdout}
 	${status}=     Get Lines Containing String  ${result.stdout}  status
@@ -177,7 +158,6 @@
 	Should Be True		${res}
 
     NEGATIVE, DUPLICATE ENTRY, CREATE AND APPLY DROP PROVISION IPv4 RULE WITH PERMIT, PROTOCOL UDP, DSCP, SOURCE QOTD AND DESTINATION
-        [Tags]           skip-unstable
         ${result}=       Run Process  st2  run  network_essentials.drop_provision  mgmt_ip\=${CASTOR_IP}  username\=${USERNAME}  password\=${PASSWORD}  acl_name\=${IPV4_ACL_NAME}  intf_type\=${VDX INT TYPE}  intf_name\=${VDX INT NAME2}  intf\=${VDX INT NAME2}  address_type\=${IPV4_ADDR_TYPE}  rule_action\=${ACTION}  source\=${SOURCED}  destination\=${DESTI}  protocol_type\=${PROTOCOL_TYPE1}  dscp\=${DSCP1}  ethertype\=${ETHERTYPE}  vlan_id\=${VLAN ID3}  seq_id\=${SEQ_ID12}  
         Log To Console   ${result.stdout}
 	${status}=     Get Lines Containing String  ${result.stdout}  status
@@ -188,7 +168,6 @@
 
 
     REMOVE AND DELETE L2 ACL, RULES USING DROP UNPROVISION
-        [Tags]           skip-unstable
         ${result}=       Run Process  st2  run  network_essentials.drop_unprovision  mgmt_ip\=${CASTOR_IP}  username\=${USERNAME}  password\=${PASSWORD}  acl_name\=${MAC_ACL_NAME}  intf_type\=${VDX INT TYPE}  intf_name\=${VDX INT NAME2}  address_type\=${MAC_ADDR_TYPE}  delete_acl\=${DELETE_ACL}  
         Log To Console   ${result.stdout}
 	${status}=     Get Lines Containing String  ${result.stdout}  status
@@ -197,7 +176,6 @@
 	Should Be True		${res}
 
     REMOVE AND DELETE L2 ACL1, RULES USING DROP UNPROVISION
-        [Tags]           skip-unstable
         ${result}=       Run Process  st2  run  network_essentials.drop_unprovision  mgmt_ip\=${CASTOR_IP}  username\=${USERNAME}  password\=${PASSWORD}  acl_name\=${MAC_ACL_NAME1}  intf_type\=${VDX INT TYPE}  intf_name\=${VDX INT NAME3}  address_type\=${MAC_ADDR_TYPE}  delete_acl\=${DELETE_ACL}  
         Log To Console   ${result.stdout}
 	${status}=     Get Lines Containing String  ${result.stdout}  status
@@ -206,7 +184,6 @@
 	Should Be True		${res}
 
     REMOVE AND DELETE L2 ACL2, RULES USING DROP UNPROVISION
-        [Tags]           skip-unstable
         ${result}=       Run Process  st2  run  network_essentials.drop_unprovision  mgmt_ip\=${CASTOR_IP}  username\=${USERNAME}  password\=${PASSWORD}  acl_name\=${MAC_ACL_NAME2}  intf_type\=${VDX INT TYPE}  intf_name\=${VDX INT NAME4}  address_type\=${MAC_ADDR_TYPE}  delete_acl\=${DELETE_ACL}  
         Log To Console   ${result.stdout}
 	${status}=     Get Lines Containing String  ${result.stdout}  status
@@ -217,7 +194,6 @@
 
 
     REMOVE AND DELETE IPV4 ACL, RULES USING DROP UNPROVISION
-        [Tags]           skip-unstable
         ${result}=       Run Process  st2  run  network_essentials.drop_unprovision  mgmt_ip\=${CASTOR_IP}  username\=${USERNAME}  password\=${PASSWORD}  acl_name\=${IPV4_ACL_NAME}  intf_type\=${VDX INT TYPE}  intf_name\=${VDX INT NAME2}  address_type\=${IPV4_ADDR_TYPE}  delete_acl\=${DELETE_ACL}    
         Log To Console   ${result.stdout}
 	${status}=     Get Lines Containing String  ${result.stdout}  status
@@ -226,7 +202,6 @@
 	Should Be True		${res}
 
     REMOVE AND DELETE IPV4 ACL1, RULES USING DROP UNPROVISION
-        [Tags]           skip-unstable
         ${result}=       Run Process  st2  run  network_essentials.drop_unprovision  mgmt_ip\=${CASTOR_IP}  username\=${USERNAME}  password\=${PASSWORD}  acl_name\=${IPV4_ACL_NAME1}  intf_type\=${VDX INT TYPE}  intf_name\=${VDX INT NAME3}  address_type\=${IPV4_ADDR_TYPE}  delete_acl\=${DELETE_ACL}    
         Log To Console   ${result.stdout}
 	${status}=     Get Lines Containing String  ${result.stdout}  status
@@ -235,7 +210,6 @@
 	Should Be True		${res}
 
     REMOVE AND DELETE IPV4 ACL2, RULES USING DROP UNPROVISION
-        [Tags]           skip-unstable
         ${result}=       Run Process  st2  run  network_essentials.drop_unprovision  mgmt_ip\=${CASTOR_IP}  username\=${USERNAME}  password\=${PASSWORD}  acl_name\=${IPV4_ACL_NAME2}  intf_type\=${VDX INT TYPE}  intf_name\=${VDX INT NAME4}  address_type\=${IPV4_ADDR_TYPE}  delete_acl\=${DELETE_ACL}    
         Log To Console   ${result.stdout}
 	${status}=     Get Lines Containing String  ${result.stdout}  status

--- a/robotfm_tests/network_essentials_acl_tests/001_Castor_Workflows.rst
+++ b/robotfm_tests/network_essentials_acl_tests/001_Castor_Workflows.rst
@@ -1,228 +1,271 @@
 .. code:: robotframework    
 	
+
     *** Test Cases ***
-
-
     
     CREATE AND APPLY DROP PROVISION L2 RULE WITH ANY SOURCE DESTINATION
         [Tags]           skip-unstable
         ${result}=       Run Process  st2  run  network_essentials.drop_provision  mgmt_ip\=${CASTOR_IP}  username\=${USERNAME}  password\=${PASSWORD}  acl_name\=${MAC_ACL_NAME}  intf_type\=${VDX INT TYPE}  intf_name\=${VDX INT NAME2}  intf\=${VDX INT NAME2}  address_type\=${MAC_ADDR_TYPE}  rule_action\=${ACTION}  source\=${SOURCE5}  seq_id\=${SEQ_ID1}  
-        ${op}=           Get Variable Value  ${result.stdout}
-        Log To Console   ${op}
-        Should Not Contain   ${op}  ERROR
-        Should Not Contain   ${op}  failed
+        Log To Console   ${result.stdout}
+	${status}=     Get Lines Containing String  ${result.stdout}  status
+        Log To Console   ${status}
+	${res}=  Evaluate  "succeeded" in """${status}"""
+	Should Be True		${res}
 
     CREATE AND APPLY DROP PROVISION L2 RULE WITH ETHERTYPE AND ANY SOURCE DESTINATION
         [Tags]           skip-unstable
         ${result}=       Run Process  st2  run  network_essentials.drop_provision  mgmt_ip\=${CASTOR_IP}  username\=${USERNAME}  password\=${PASSWORD}  acl_name\=${MAC_ACL_NAME}  intf_type\=${VDX INT TYPE}  intf_name\=${VDX INT NAME2}  intf\=${VDX INT NAME2}  address_type\=${MAC_ADDR_TYPE}  rule_action\=${ACTION}  source\=${SOURCE5}  destination\=${DEST5}  seq_id\=${SEQ_ID2}  ethertype\=${ETHERTYPE3}
-        ${op}=           Get Variable Value  ${result.stdout}
-        Log To Console   ${op}
-        Should Not Contain   ${op}  ERROR
-        Should Not Contain   ${op}  failed
+        Log To Console   ${result.stdout}
+	${status}=     Get Lines Containing String  ${result.stdout}  status
+        Log To Console   ${status}
+	${res}=  Evaluate  "succeeded" in """${status}"""
+	Should Be True		${res}
 
     CREATE AND APPLY DROP PROVISION L2 RULE WITH SOURCE_MAC AND DESTINATION
         [Tags]           skip-unstable
         ${result}=       Run Process  st2  run  network_essentials.drop_provision  mgmt_ip\=${CASTOR_IP}  username\=${USERNAME}  password\=${PASSWORD}  acl_name\=${MAC_ACL_NAME1}  intf_type\=${VDX INT TYPE}  intf_name\=${VDX INT NAME3}  intf\=${VDX INT NAME3}  address_type\=${MAC_ADDR_TYPE}  rule_action\=${ACTION}  source\=${SOURCE1}  src_mac_addr_mask\=${SRC_MAC_ADDR_MASK1}  seq_id\=${SEQ_ID3}  ethertype\=${ETHERTYPE2}
-        ${op}=           Get Variable Value  ${result.stdout}
-        Log To Console   ${op}
-        Should Not Contain   ${op}  ERROR
-        Should Not Contain   ${op}  failed
+        Log To Console   ${result.stdout}
+	${status}=     Get Lines Containing String  ${result.stdout}  status
+        Log To Console   ${status}
+	${res}=  Evaluate  "succeeded" in """${status}"""
+	Should Be True		${res}
 
     CREATE AND APPLY DROP PROVISION L2 RULE WITH SOURCE_MAC, SRC_MAC_MASK AND DESTINATION
         [Tags]           skip-unstable
         ${result}=       Run Process  st2  run  network_essentials.drop_provision  mgmt_ip\=${CASTOR_IP}  username\=${USERNAME}  password\=${PASSWORD}  acl_name\=${MAC_ACL_NAME}  intf_type\=${VDX INT TYPE}  intf_name\=${VDX INT NAME2}  intf\=${VDX INT NAME2}  address_type\=${MAC_ADDR_TYPE}  rule_action\=${ACTION}  source\=${SOURCE1}  src_mac_addr_mask\=${SRC_MAC_ADDR_MASK}  seq_id\=${SEQ_ID4}  
-        ${op}=           Get Variable Value  ${result.stdout}
-        Log To Console   ${op}
-        Should Not Contain   ${op}  ERROR
-        Should Not Contain   ${op}  failed
+        Log To Console   ${result.stdout}
+	${status}=     Get Lines Containing String  ${result.stdout}  status
+        Log To Console   ${status}
+	${res}=  Evaluate  "succeeded" in """${status}"""
+	Should Be True		${res}
 
     CREATE AND APPLY DROP PROVISION L2 RULE WITH SOURCE_MAC, DESTINATION_MAC AND VLAN
         [Tags]           skip-unstable
         ${result}=       Run Process  st2  run  network_essentials.drop_provision  mgmt_ip\=${CASTOR_IP}  username\=${USERNAME}  password\=${PASSWORD}  acl_name\=${MAC_ACL_NAME2}  intf_type\=${VDX INT TYPE}  intf_name\=${VDX INT NAME4}  intf\=${VDX INT NAME4}  address_type\=${MAC_ADDR_TYPE}  rule_action\=${ACTION}  source\=${SOURCE1}  src_mac_addr_mask\=${SRC_MAC_ADDR_MASK1}  destination\=${DEST1}  dst_mac_addr_mask\=${DEST_MAC_ADDR_MASK3}  seq_id\=${SEQ_ID5}  ethertype\=${ETHERTYPE2}  vlan_id\=${VLAN ID7}
-        ${op}=           Get Variable Value  ${result.stdout}
-        Log To Console   ${op}
-        Should Not Contain   ${op}  ERROR
-        Should Not Contain   ${op}  failed
+        Log To Console   ${result.stdout}
+	${status}=     Get Lines Containing String  ${result.stdout}  status
+        Log To Console   ${status}
+	${res}=  Evaluate  "succeeded" in """${status}"""
+	Should Be True		${res}
 
     CREATE AND APPLY DROP PROVISION L2 RULE WITH DESTINATION_MAC AND VLAN
         [Tags]           skip-unstable
         ${result}=       Run Process  st2  run  network_essentials.drop_provision  mgmt_ip\=${CASTOR_IP}  username\=${USERNAME}  password\=${PASSWORD}  acl_name\=${MAC_ACL_NAME}  intf_type\=${VDX INT TYPE}  intf_name\=${VDX INT NAME2}  intf\=${VDX INT NAME2}  address_type\=${MAC_ADDR_TYPE}  rule_action\=${ACTION}  source\=${SOURCE5}  destination\=${DEST2}  dst_mac_addr_mask\=${DEST_MAC_ADDR_MASK3}  seq_id\=${SEQ_ID6}  ethertype\=${ETHERTYPE2}  vlan_id\=${VLAN ID5}
-        ${op}=           Get Variable Value  ${result.stdout}
-        Log To Console   ${op}
-        Should Not Contain   ${op}  ERROR
-        Should Not Contain   ${op}  failed
+        Log To Console   ${result.stdout}
+	${status}=     Get Lines Containing String  ${result.stdout}  status
+        Log To Console   ${status}
+	${res}=  Evaluate  "succeeded" in """${status}"""
+	Should Be True		${res}
 
     CREATE AND APPLY DROP PROVISION L2 RULE WITH ANY SOURCE, DESTINATION_MAC AND VLAN
         [Tags]           skip-unstable
         ${result}=       Run Process  st2  run  network_essentials.drop_provision  mgmt_ip\=${CASTOR_IP}  username\=${USERNAME}  password\=${PASSWORD}  acl_name\=${MAC_ACL_NAME}  intf_type\=${VDX INT TYPE}  intf_name\=${VDX INT NAME2}  intf\=${VDX INT NAME2}  address_type\=${MAC_ADDR_TYPE}  rule_action\=${ACTION}  source\=${SOURCE5}  destination\=${DEST2}  dst_mac_addr_mask\=${DEST_MAC_ADDR_MASK2}  seq_id\=${SEQ_ID7}  ethertype\=${ETHERTYPE2}  vlan_id\=${VLAN ID6}
-        ${op}=           Get Variable Value  ${result.stdout}
-        Log To Console   ${op}
-        Should Not Contain   ${op}  ERROR
-        Should Not Contain   ${op}  failed
+        Log To Console   ${result.stdout}
+	${status}=     Get Lines Containing String  ${result.stdout}  status
+        Log To Console   ${status}
+	${res}=  Evaluate  "succeeded" in """${status}"""
+	Should Be True		${res}
 
     NEGATIVE, DUPLICATE ENTRY, CREATE AND APPLY DROP PROVISION L2 RULE WITH ANY SOURCE, DESTINATION_MAC AND VLAN
         [Tags]           skip-unstable
         ${result}=       Run Process  st2  run  network_essentials.drop_provision  mgmt_ip\=${CASTOR_IP}  username\=${USERNAME}  password\=${PASSWORD}  acl_name\=${MAC_ACL_NAME}  intf_type\=${VDX INT TYPE}  intf_name\=${VDX INT NAME2}  intf\=${VDX INT NAME2}  address_type\=${MAC_ADDR_TYPE}  rule_action\=${ACTION}  source\=${SOURCE5}  destination\=${DEST2}  dst_mac_addr_mask\=${DEST_MAC_ADDR_MASK2}  seq_id\=${SEQ_ID7}  ethertype\=${ETHERTYPE2}  vlan_id\=${VLAN ID6}
-        ${op}=           Get Variable Value  ${result.stdout}
-        Log To Console   ${op}
-        Should Contain   ${op}  ERROR
-        Should Contain   ${op}  failed
+        Log To Console   ${result.stdout}
+	${status}=     Get Lines Containing String  ${result.stdout}  status
+        Log To Console   ${status}
+	${res}=  Evaluate  "failed" in """${status}"""
+	Should Be True		${res}
         
-
 
 
     CREATE AND APPLY DROP PROVISION IPv4 RULE WITH PROTOCOL AND ANY SOURCE DESTINATION
         [Tags]           skip-unstable
         ${result}=       Run Process  st2  run  network_essentials.drop_provision  mgmt_ip\=${CASTOR_IP}  username\=${USERNAME}  password\=${PASSWORD}  acl_name\=${IPV4_ACL_NAME}  intf_type\=${VDX INT TYPE}  intf_name\=${VDX INT NAME2}  intf\=${VDX INT NAME2}  address_type\=${IPV4_ADDR_TYPE}  rule_action\=${ACTION}  source\=${SOURCEF}  destination\=${DESTF}  protocol_type\=${PROTOCOL_TYPE4}  ethertype\=${ETHERTYPE}  seq_id\=${SEQ_ID1}  
-        ${op}=           Get Variable Value  ${result.stdout}
-        Log To Console   ${op}
-        Should Not Contain   ${op}  ERROR
-        Should Not Contain   ${op}  failed
+        Log To Console   ${result.stdout}
+	${status}=     Get Lines Containing String  ${result.stdout}  status
+        Log To Console   ${status}
+	${res}=  Evaluate  "succeeded" in """${status}"""
+	Should Be True		${res}
 
     CREATE AND APPLY DROP PROVISION IPv4 RULE WITH PROTOCOL AND DESTINATION
         [Tags]           skip-unstable
         ${result}=       Run Process  st2  run  network_essentials.drop_provision  mgmt_ip\=${CASTOR_IP}  username\=${USERNAME}  password\=${PASSWORD}  acl_name\=${IPV4_ACL_NAME}  intf_type\=${VDX INT TYPE}  intf_name\=${VDX INT NAME2}  intf\=${VDX INT NAME2}  address_type\=${IPV4_ADDR_TYPE}  rule_action\=${ACTION}  source\=${SOURCEF}  destination\=${DESTA}  protocol_type\=${PROTOCOL_TYPE1}  ethertype\=${ETHERTYPE}  vlan_id\=${VLAN ID5}  seq_id\=${SEQ_ID2}  
-        ${op}=           Get Variable Value  ${result.stdout}
-        Log To Console   ${op}
-        Should Not Contain   ${op}  ERROR
-        Should Not Contain   ${op}  failed
+        Log To Console   ${result.stdout}
+	${status}=     Get Lines Containing String  ${result.stdout}  status
+        Log To Console   ${status}
+	${res}=  Evaluate  "succeeded" in """${status}"""
+	Should Be True		${res}
 
     CREATE AND APPLY DROP PROVISION IPv4 RULE WITH PROTOCOL ICMP, SOURCE AND DESTINATION
         [Tags]           skip-unstable
         ${result}=       Run Process  st2  run  network_essentials.drop_provision  mgmt_ip\=${CASTOR_IP}  username\=${USERNAME}  password\=${PASSWORD}  acl_name\=${IPV4_ACL_NAME1}  intf_type\=${VDX INT TYPE}  intf_name\=${VDX INT NAME3}  intf\=${VDX INT NAME3}  address_type\=${IPV4_ADDR_TYPE}  rule_action\=${ACTION}  source\=${SOURCEA}  destination\=${DESTA}  protocol_type\=${PROTOCOL_TYPE3}  seq_id\=${SEQ_ID3}  
-        ${op}=           Get Variable Value  ${result.stdout}
-        Log To Console   ${op}
-        Should Not Contain   ${op}  ERROR
-        Should Not Contain   ${op}  failed
+        Log To Console   ${result.stdout}
+	${status}=     Get Lines Containing String  ${result.stdout}  status
+        Log To Console   ${status}
+	${res}=  Evaluate  "succeeded" in """${status}"""
+	Should Be True		${res}
 
     CREATE AND APPLY DROP PROVISION IPv4 RULE WITH PROTOCOL UDP, SOURCE AND DESTINATION
         [Tags]           skip-unstable
         ${result}=       Run Process  st2  run  network_essentials.drop_provision  mgmt_ip\=${CASTOR_IP}  username\=${USERNAME}  password\=${PASSWORD}  acl_name\=${IPV4_ACL_NAME}  intf_type\=${VDX INT TYPE}  intf_name\=${VDX INT NAME2}  intf\=${VDX INT NAME2}  address_type\=${IPV4_ADDR_TYPE}  rule_action\=${ACTION}  source\=${SOURCEH}  destination\=${DESTA}  protocol_type\=${PROTOCOL_TYPE1}  ethertype\=${ETHERTYPE}  vlan_id\=${VLAN ID2}  seq_id\=${SEQ_ID4}  
-        ${op}=           Get Variable Value  ${result.stdout}
-        Log To Console   ${op}
-        Should Not Contain   ${op}  ERROR
-        Should Not Contain   ${op}  failed
+        Log To Console   ${result.stdout}
+	${status}=     Get Lines Containing String  ${result.stdout}  status
+        Log To Console   ${status}
+	${res}=  Evaluate  "succeeded" in """${status}"""
+	Should Be True		${res}
 
     CREATE AND APPLY DROP PROVISION IPv4 RULE WITH PROTOCOL TCP, SOURCE AND DESTINATION
         [Tags]           skip-unstable
         ${result}=       Run Process  st2  run  network_essentials.drop_provision  mgmt_ip\=${CASTOR_IP}  username\=${USERNAME}  password\=${PASSWORD}  acl_name\=${IPV4_ACL_NAME}  intf_type\=${VDX INT TYPE}  intf_name\=${VDX INT NAME2}  intf\=${VDX INT NAME2}  address_type\=${IPV4_ADDR_TYPE}  rule_action\=${ACTION}  source\=${SOURCEI}  destination\=${DESTB}  protocol_type\=${PROTOCOL_TYPE2}  seq_id\=${SEQ_ID5}  
-        ${op}=           Get Variable Value  ${result.stdout}
-        Log To Console   ${op}
-        Should Not Contain   ${op}  ERROR
-        Should Not Contain   ${op}  failed
+        Log To Console   ${result.stdout}
+	${status}=     Get Lines Containing String  ${result.stdout}  status
+        Log To Console   ${status}
+	${res}=  Evaluate  "succeeded" in """${status}"""
+	Should Be True		${res}
 
     CREATE AND APPLY DROP PROVISION IPv4 RULE WITH PROTOCOL TCP, SOURCE DOMAIN AND DESTINATION
         [Tags]           skip-unstable
         ${result}=       Run Process  st2  run  network_essentials.drop_provision  mgmt_ip\=${CASTOR_IP}  username\=${USERNAME}  password\=${PASSWORD}  acl_name\=${IPV4_ACL_NAME2}  intf_type\=${VDX INT TYPE}  intf_name\=${VDX INT NAME4}  intf\=${VDX INT NAME4}  address_type\=${IPV4_ADDR_TYPE}  rule_action\=${ACTION}  source\=${SOURCEI}  destination\=${DESTB}  protocol_type\=${PROTOCOL_TYPE2}  ethertype\=${ETHERTYPE3}  vlan_id\=${VLAN ID1}  seq_id\=${SEQ_ID6}  
-        ${op}=           Get Variable Value  ${result.stdout}
-        Log To Console   ${op}
-        Should Not Contain   ${op}  ERROR
-        Should Not Contain   ${op}  failed
+        Log To Console   ${result.stdout}
+	${status}=     Get Lines Containing String  ${result.stdout}  status
+        Log To Console   ${status}
+	${res}=  Evaluate  "succeeded" in """${status}"""
+	Should Be True		${res}
 
     CREATE AND APPLY DROP PROVISION IPv4 RULE WITH PROTOCOL, DSCP, SOURCE AND DESTINATION
         [Tags]           skip-unstable
         ${result}=       Run Process  st2  run  network_essentials.drop_provision  mgmt_ip\=${CASTOR_IP}  username\=${USERNAME}  password\=${PASSWORD}  acl_name\=${IPV4_ACL_NAME}  intf_type\=${VDX INT TYPE}  intf_name\=${VDX INT NAME2}  intf\=${VDX INT NAME2}  address_type\=${IPV4_ADDR_TYPE}  rule_action\=${ACTION}  source\=${SOURCEI}  destination\=${DESTB}  protocol_type\=${PROTOCOL_TYPE2}  dscp\=${DSCP2}  ethertype\=${ETHERTYPE}  vlan_id\=${VLAN ID3}  seq_id\=${SEQ_ID7}  
-        ${op}=           Get Variable Value  ${result.stdout}
-        Log To Console   ${op}
-        Should Not Contain   ${op}  ERROR
-        Should Not Contain   ${op}  failed
+        Log To Console   ${result.stdout}
+	${status}=     Get Lines Containing String  ${result.stdout}  status
+        Log To Console   ${status}
+	${res}=  Evaluate  "succeeded" in """${status}"""
+	Should Be True		${res}
 
     CREATE AND APPLY DROP PROVISION IPv4 RULE WITH PROTOCOL UDP, DSCP, SOURCE NTP AND DESTINATION
         [Tags]           skip-unstable
         ${result}=       Run Process  st2  run  network_essentials.drop_provision  mgmt_ip\=${CASTOR_IP}  username\=${USERNAME}  password\=${PASSWORD}  acl_name\=${IPV4_ACL_NAME1}  intf_type\=${VDX INT TYPE}  intf_name\=${VDX INT NAME3}  intf\=${VDX INT NAME3}  address_type\=${IPV4_ADDR_TYPE}  rule_action\=${ACTION}  source\=${SOURCEG}  destination\=${DESTC}  protocol_type\=${PROTOCOL_TYPE1}  dscp\=${DSCP1}  ethertype\=${ETHERTYPE}  vlan_id\=${VLAN ID4}  seq_id\=${SEQ_ID8}  
-        ${op}=           Get Variable Value  ${result.stdout}
-        Log To Console   ${op}
-        Should Not Contain   ${op}  ERROR
-        Should Not Contain   ${op}  failed
+        Log To Console   ${result.stdout}
+	${status}=     Get Lines Containing String  ${result.stdout}  status
+        Log To Console   ${status}
+	${res}=  Evaluate  "succeeded" in """${status}"""
+	Should Be True		${res}
 
     CREATE AND APPLY DROP PROVISION IPv4 RULE WITH PROTOCOL UDP, DSCP, SOURCE CHARGEN AND DESTINATION
         [Tags]           skip-unstable
         ${result}=       Run Process  st2  run  network_essentials.drop_provision  mgmt_ip\=${CASTOR_IP}  username\=${USERNAME}  password\=${PASSWORD}  acl_name\=${IPV4_ACL_NAME}  intf_type\=${VDX INT TYPE}  intf_name\=${VDX INT NAME2}  intf\=${VDX INT NAME2}  address_type\=${IPV4_ADDR_TYPE}  rule_action\=${ACTION}  source\=${SOURCEC}  destination\=${DESTH}  protocol_type\=${PROTOCOL_TYPE1}  dscp\=${DSCP4}  ethertype\=${ETHERTYPE}  vlan_id\=${VLAN ID5}  seq_id\=${SEQ_ID9}  
-        ${op}=           Get Variable Value  ${result.stdout}
-        Log To Console   ${op}
-        Should Not Contain   ${op}  ERROR
-        Should Not Contain   ${op}  failed
+        Log To Console   ${result.stdout}
+	${status}=     Get Lines Containing String  ${result.stdout}  status
+        Log To Console   ${status}
+	${res}=  Evaluate  "succeeded" in """${status}"""
+	Should Be True		${res}
 
     CREATE AND APPLY DROP PROVISION IPv4 RULE WITH PROTOCOL UDP, DSCP, SOURCE SSDP AND DESTINATION
         [Tags]           skip-unstable
         ${result}=       Run Process  st2  run  network_essentials.drop_provision  mgmt_ip\=${CASTOR_IP}  username\=${USERNAME}  password\=${PASSWORD}  acl_name\=${IPV4_ACL_NAME2}  intf_type\=${VDX INT TYPE}  intf_name\=${VDX INT NAME4}  intf\=${VDX INT NAME4}  address_type\=${IPV4_ADDR_TYPE}  rule_action\=${ACTION}  source\=${SOURCEE}  destination\=${DESTI}  protocol_type\=${PROTOCOL_TYPE1}  dscp\=${DSCP3}  ethertype\=${ETHERTYPE}  vlan_id\=${VLAN ID2}  seq_id\=${SEQ_ID10}  
-        ${op}=           Get Variable Value  ${result.stdout}
-        Log To Console   ${op}
-        Should Not Contain   ${op}  ERROR
-        Should Not Contain   ${op}  failed
+        Log To Console   ${result.stdout}
+	${status}=     Get Lines Containing String  ${result.stdout}  status
+        Log To Console   ${status}
+	${res}=  Evaluate  "succeeded" in """${status}"""
+	Should Be True		${res}
 
     CREATE AND APPLY DROP PROVISION IPv4 RULE WITH PROTOCOL UDP, DSCP, SOURCE QOTD AND DESTINATION
         [Tags]           skip-unstable
         ${result}=       Run Process  st2  run  network_essentials.drop_provision  mgmt_ip\=${CASTOR_IP}  username\=${USERNAME}  password\=${PASSWORD}  acl_name\=${IPV4_ACL_NAME}  intf_type\=${VDX INT TYPE}  intf_name\=${VDX INT NAME2}  intf\=${VDX INT NAME2}  address_type\=${IPV4_ADDR_TYPE}  rule_action\=${ACTION}  source\=${SOURCED}  destination\=${DESTI}  protocol_type\=${PROTOCOL_TYPE1}  dscp\=${DSCP1}  ethertype\=${ETHERTYPE}  vlan_id\=${VLAN ID3}  seq_id\=${SEQ_ID11}  
-        ${op}=           Get Variable Value  ${result.stdout}
-        Log To Console   ${op}
-        Should Not Contain   ${op}  ERROR
-        Should Not Contain   ${op}  failed
+        Log To Console   ${result.stdout}
+	${status}=     Get Lines Containing String  ${result.stdout}  status
+        Log To Console   ${status}
+	${res}=  Evaluate  "succeeded" in """${status}"""
+	Should Be True		${res}
 
     NEGATIVE, DUPLICATE ENTRY, CREATE AND APPLY DROP PROVISION IPv4 RULE WITH PERMIT, PROTOCOL UDP, DSCP, SOURCE QOTD AND DESTINATION
         [Tags]           skip-unstable
         ${result}=       Run Process  st2  run  network_essentials.drop_provision  mgmt_ip\=${CASTOR_IP}  username\=${USERNAME}  password\=${PASSWORD}  acl_name\=${IPV4_ACL_NAME}  intf_type\=${VDX INT TYPE}  intf_name\=${VDX INT NAME2}  intf\=${VDX INT NAME2}  address_type\=${IPV4_ADDR_TYPE}  rule_action\=${ACTION}  source\=${SOURCED}  destination\=${DESTI}  protocol_type\=${PROTOCOL_TYPE1}  dscp\=${DSCP1}  ethertype\=${ETHERTYPE}  vlan_id\=${VLAN ID3}  seq_id\=${SEQ_ID12}  
-        ${op}=           Get Variable Value  ${result.stdout}
-        Log To Console   ${op}
-        Should Contain   ${op}  ERROR
-        Should Contain   ${op}  failed
+        Log To Console   ${result.stdout}
+	${status}=     Get Lines Containing String  ${result.stdout}  status
+        Log To Console   ${status}
+	${res}=  Evaluate  "failed" in """${status}"""
+	Should Be True		${res}
         
 
 
     REMOVE AND DELETE L2 ACL, RULES USING DROP UNPROVISION
         [Tags]           skip-unstable
         ${result}=       Run Process  st2  run  network_essentials.drop_unprovision  mgmt_ip\=${CASTOR_IP}  username\=${USERNAME}  password\=${PASSWORD}  acl_name\=${MAC_ACL_NAME}  intf_type\=${VDX INT TYPE}  intf_name\=${VDX INT NAME2}  address_type\=${MAC_ADDR_TYPE}  delete_acl\=${DELETE_ACL}  
-        ${op}=           Get Variable Value  ${result.stdout}
-        Log To Console   ${op}
-        Should Not Contain   ${op}  ERROR
-        Should Not Contain   ${op}  failed
+        Log To Console   ${result.stdout}
+	${status}=     Get Lines Containing String  ${result.stdout}  status
+        Log To Console   ${status}
+	${res}=  Evaluate  "succeeded" in """${status}"""
+	Should Be True		${res}
 
     REMOVE AND DELETE L2 ACL1, RULES USING DROP UNPROVISION
         [Tags]           skip-unstable
         ${result}=       Run Process  st2  run  network_essentials.drop_unprovision  mgmt_ip\=${CASTOR_IP}  username\=${USERNAME}  password\=${PASSWORD}  acl_name\=${MAC_ACL_NAME1}  intf_type\=${VDX INT TYPE}  intf_name\=${VDX INT NAME3}  address_type\=${MAC_ADDR_TYPE}  delete_acl\=${DELETE_ACL}  
-        ${op}=           Get Variable Value  ${result.stdout}
-        Log To Console   ${op}
-        Should Not Contain   ${op}  ERROR
-        Should Not Contain   ${op}  failed
+        Log To Console   ${result.stdout}
+	${status}=     Get Lines Containing String  ${result.stdout}  status
+        Log To Console   ${status}
+	${res}=  Evaluate  "succeeded" in """${status}"""
+	Should Be True		${res}
 
     REMOVE AND DELETE L2 ACL2, RULES USING DROP UNPROVISION
         [Tags]           skip-unstable
         ${result}=       Run Process  st2  run  network_essentials.drop_unprovision  mgmt_ip\=${CASTOR_IP}  username\=${USERNAME}  password\=${PASSWORD}  acl_name\=${MAC_ACL_NAME2}  intf_type\=${VDX INT TYPE}  intf_name\=${VDX INT NAME4}  address_type\=${MAC_ADDR_TYPE}  delete_acl\=${DELETE_ACL}  
-        ${op}=           Get Variable Value  ${result.stdout}
-        Log To Console   ${op}
-        Should Not Contain   ${op}  ERROR
-        Should Not Contain   ${op}  failed
+        Log To Console   ${result.stdout}
+	${status}=     Get Lines Containing String  ${result.stdout}  status
+        Log To Console   ${status}
+	${res}=  Evaluate  "succeeded" in """${status}"""
+	Should Be True		${res}
 
 
 
     REMOVE AND DELETE IPV4 ACL, RULES USING DROP UNPROVISION
         [Tags]           skip-unstable
         ${result}=       Run Process  st2  run  network_essentials.drop_unprovision  mgmt_ip\=${CASTOR_IP}  username\=${USERNAME}  password\=${PASSWORD}  acl_name\=${IPV4_ACL_NAME}  intf_type\=${VDX INT TYPE}  intf_name\=${VDX INT NAME2}  address_type\=${IPV4_ADDR_TYPE}  delete_acl\=${DELETE_ACL}    
-        ${op}=           Get Variable Value  ${result.stdout}
-        Log To Console   ${op}
-        Should Not Contain   ${op}  ERROR
-        Should Not Contain   ${op}  failed
+        Log To Console   ${result.stdout}
+	${status}=     Get Lines Containing String  ${result.stdout}  status
+        Log To Console   ${status}
+	${res}=  Evaluate  "succeeded" in """${status}"""
+	Should Be True		${res}
 
     REMOVE AND DELETE IPV4 ACL1, RULES USING DROP UNPROVISION
         [Tags]           skip-unstable
         ${result}=       Run Process  st2  run  network_essentials.drop_unprovision  mgmt_ip\=${CASTOR_IP}  username\=${USERNAME}  password\=${PASSWORD}  acl_name\=${IPV4_ACL_NAME1}  intf_type\=${VDX INT TYPE}  intf_name\=${VDX INT NAME3}  address_type\=${IPV4_ADDR_TYPE}  delete_acl\=${DELETE_ACL}    
-        ${op}=           Get Variable Value  ${result.stdout}
-        Log To Console   ${op}
-        Should Not Contain   ${op}  ERROR
-        Should Not Contain   ${op}  failed
+        Log To Console   ${result.stdout}
+	${status}=     Get Lines Containing String  ${result.stdout}  status
+        Log To Console   ${status}
+	${res}=  Evaluate  "succeeded" in """${status}"""
+	Should Be True		${res}
 
     REMOVE AND DELETE IPV4 ACL2, RULES USING DROP UNPROVISION
         [Tags]           skip-unstable
         ${result}=       Run Process  st2  run  network_essentials.drop_unprovision  mgmt_ip\=${CASTOR_IP}  username\=${USERNAME}  password\=${PASSWORD}  acl_name\=${IPV4_ACL_NAME2}  intf_type\=${VDX INT TYPE}  intf_name\=${VDX INT NAME4}  address_type\=${IPV4_ADDR_TYPE}  delete_acl\=${DELETE_ACL}    
+        Log To Console   ${result.stdout}
+	${status}=     Get Lines Containing String  ${result.stdout}  status
+        Log To Console   ${status}
+	${res}=  Evaluate  "succeeded" in """${status}"""
+	Should Be True		${res}
+
+
+    DELETE SWITCHPORT FOR INTERFACE VDX INT NAME2
+        ${result}=       Run Process  st2  run  network_essentials.delete_switchport  mgmt_ip\=${CASTOR_IP}  username\=${USERNAME}  password\=${PASSWORD}  intf_type\=${VDX INT TYPE}  intf_name\=${VDX INT NAME2}
         ${op}=           Get Variable Value  ${result.stdout}
         Log To Console   ${op}
         Should Not Contain   ${op}  ERROR
-        Should Not Contain   ${op}  failed
 
+    DELETE SWITCHPORT FOR INTERFACE VDX INT NAME3
+        ${result}=       Run Process  st2  run  network_essentials.delete_switchport  mgmt_ip\=${CASTOR_IP}  username\=${USERNAME}  password\=${PASSWORD}  intf_type\=${VDX INT TYPE}  intf_name\=${VDX INT NAME3}
+        ${op}=           Get Variable Value  ${result.stdout}
+        Log To Console   ${op}
+        Should Not Contain   ${op}  ERROR
+
+    DELETE SWITCHPORT FOR INTERFACE VDX INT NAME4
+        ${result}=       Run Process  st2  run  network_essentials.delete_switchport  mgmt_ip\=${CASTOR_IP}  username\=${USERNAME}  password\=${PASSWORD}  intf_type\=${VDX INT TYPE}  intf_name\=${VDX INT NAME4}
+        ${op}=           Get Variable Value  ${result.stdout}
+        Log To Console   ${op}
+        Should Not Contain   ${op}  ERROR
 	
     *** Settings ***
     Library             OperatingSystem
     Library             Process
+    Library             String
     Resource            ../resource.robot
     Suite teardown         resource.Clean CastorSwitch_Network_Essentials
     Variables           001_ACL.yaml


### PR DESCRIPTION
1. Fix ACL CI tests to do proper validation for drop provision workflows.
2. Clean up stale switchport configuration
3. Remove skip-unstable tags so that the tests will be run for both stable and unstable releases.
4. Add String Library to use string related API's provided by robot framework

Since CI server is down executed the test cases using pybot on local server. 

Will enable the ACL tests (currently disabled) in bwc-ci as part of seperate PR.

Logs:
============================== 10.20.238.106 ==============================
setup_teardown/NOS_switch_configs/001_NOS_Network_Essentials_10_20_238_106.config
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
001 Castor Workflows                                                  | PASS |
29 critical tests, 29 passed, 0 failed
29 tests total, 29 passed, 0 failed
==============================================================================
Output:  /home/ubuntu/bwc-tests/robotfm_tests/ne_acl_test_output.xml
Log:     /home/ubuntu/bwc-tests/robotfm_tests/ne_acl_log.html
Report:  /home/ubuntu/bwc-tests/robotfm_tests/ne_acl_report.html

============================== 10.20.238.106 ==============================
setup_teardown/NOS_switch_configs/001_NOS_Network_Essentials_10_20_238_106.config
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
001 Castor ACL Creation                                               | PASS |
81 critical tests, 81 passed, 0 failed
81 tests total, 81 passed, 0 failed
==============================================================================
Output:  /home/ubuntu/bwc-tests/robotfm_tests/ne_acl_test_output.xml
Log:     /home/ubuntu/bwc-tests/robotfm_tests/ne_acl_log.html
Report:  /home/ubuntu/bwc-tests/robotfm_tests/ne_acl_report.html